### PR TITLE
Changes from background agent bc-e62d02e8-1254-47ca-b54c-e23faad5573f

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,19 @@ A lightweight Spring Boot wrapper over the WorldNews Top News endpoint.
 - Java 17+
 - Maven 3.9+
 
-2) Configure API key
+2) Build the project
+```bash
+mvn clean compile
+```
+
+3) Configure API key
 
 Export your WorldNews API key (get one from their docs/console):
 ```bash
 export WORLDNEWS_API_KEY=YOUR_KEY
 ```
 
-3) Run the app
+4) Run the app
 ```bash
 mvn spring-boot:run
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jacoco.version>0.8.12</jacoco.version>
         <wiremock.version>2.35.2</wiremock.version>
+        <mockito.version>5.14.2</mockito.version>
+        <byte-buddy.version>1.15.10</byte-buddy.version>
     </properties>
 
     <dependencies>
@@ -69,6 +71,19 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>${byte-buddy.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+            <version>${byte-buddy.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -138,6 +153,7 @@
                 <version>3.2.5</version>
                 <configuration>
                     <useModulePath>false</useModulePath>
+                    <argLine>@{argLine} -Dnet.bytebuddy.experimental=true</argLine>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Fix Maven test errors for Java 24 compatibility and add build instructions to README.

Tests were failing due to an incompatibility between Mockito/Byte Buddy and Java 24. This PR updates Mockito and Byte Buddy dependencies to versions supporting Java 24 and adds a JVM argument (`-Dnet.bytebuddy.experimental=true`) to the Surefire plugin to enable experimental Java 24 support. The README has also been updated with the `mvn clean compile` command for building.

---
<a href="https://cursor.com/background-agent?bcId=bc-e62d02e8-1254-47ca-b54c-e23faad5573f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e62d02e8-1254-47ca-b54c-e23faad5573f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

